### PR TITLE
update vue.js to 2.6.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/vue-hcaptcha",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25971,9 +25971,9 @@
       }
     },
     "vue": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
     "vue-class-component": {
       "version": "6.3.2",
@@ -26221,9 +26221,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
-      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
+      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "vue": "2.6.11"
+    "vue": "^2.6.12"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -59,7 +59,7 @@
     "vue-jest": "^3.0.2",
     "vue-loader": "^15.4.2",
     "vue-server-renderer": "^2.5.21",
-    "vue-template-compiler": "2.6.11",
+    "vue-template-compiler": "^2.6.12",
     "webpack": "^4.28.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
closes https://github.com/hCaptcha/vue-hcaptcha/issues/16

I'm not sure why vue.js isn't a dev dep, but I didn't dive deep enough into the codebase to determine if it was reasonable to move vue.js to dev deps. If it can be moved, another PR can be made to address that. 

I just want to be able to update nuxt.js in the short term and can circle back another day to resolve the dependency issue. 