### PR TITLE
Move vue.js to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25973,7 +25973,8 @@
     "vue": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
-      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==",
+      "dev": true
     },
     "vue-class-component": {
       "version": "6.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcaptcha/vue-hcaptcha",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25971,9 +25971,9 @@
       }
     },
     "vue": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
     "vue-class-component": {
       "version": "6.3.2",
@@ -26221,9 +26221,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
-      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
+      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "vue": "2.6.11"
+    "vue": "^2.6.12"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -59,7 +59,7 @@
     "vue-jest": "^3.0.2",
     "vue-loader": "^15.4.2",
     "vue-server-renderer": "^2.5.21",
-    "vue-template-compiler": "2.6.11",
+    "vue-template-compiler": "^2.6.12",
     "webpack": "^4.28.1"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build"
   },
-  "dependencies": {
-    "vue": "^2.6.12"
-  },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
@@ -56,6 +53,7 @@
     "jsdom-global": "^3.0.2",
     "mini-css-extract-plugin": "^0.4.2",
     "thread-loader": "^1.2.0",
+    "vue": "^2.6.12",
     "vue-jest": "^3.0.2",
     "vue-loader": "^15.4.2",
     "vue-server-renderer": "^2.5.21",


### PR DESCRIPTION
After a basic scan of the repo and quick local test of compatibility, it appears that vue.js is only needed when developing this package, and is *not* needed for usage. Furthermore it seems that including this dependency *not* in dev dependencies can actually cause *more* issues as it can cause conflicts with packages such as nuxt.js, which *do* need to specify the vue.js dependency.

As such, if we omit this requirement from vue-hcaptcha, it should increase compatibility with other plugins and frameworks .

This branch is built off PR #17 which updates the vue.js dependency to the latest version, and simply moves the vue.js dependency to dev deps.

Verifying PR:

1. install from forked repo:
```
$ npm install @hcaptcha/vue-hcaptcha@bitwave-tv/vue-hcaptcha#dfca6ed64ccb24144965b0dc8ee1446fdecab759
```

2. Check that we have an older version of vue.js installed to force the situation of mismatched vue.js versions:
```
$ npm ls vue
`-- nuxt@2.14.3
  +-- @nuxt/builder@2.14.3
  | `-- @nuxt/vue-app@2.14.3
  |   `-- vue@2.6.11
  `-- @nuxt/core@2.14.3
    `-- @nuxt/vue-renderer@2.14.3
      `-- vue@2.6.11  deduped
```

Note that this PR uses 2.6.12 so the installed version of 2.6.11 would be `mismatched` and cause errors during build without this PR.

3. Test that we can buid with `npm run build`
4. Verify hCAPTCHA still appears.

![image](https://user-images.githubusercontent.com/45262335/92273776-d7262200-eea0-11ea-91db-19fcd28b325e.png)

CAPTCHA still appears correctly in page, despite move vue.js to dev dependencies and using an older vue.js version to build the server. 
Thus this PR should remove the reliance on a hardcoded and fixed vue.js version. 

edit: would also address and resolve #16 