### PR TITLE
Added v-model support

### DIFF
--- a/packages/vue2/src/hcaptcha.vue
+++ b/packages/vue2/src/hcaptcha.vue
@@ -7,7 +7,15 @@ import {loadApiEndpointIfNotAlready} from './hcaptcha-script';
 
 export default {
     name: 'VueHcaptcha',
+    model: {
+      prop: 'value',
+      event: 'verify',
+    },
     props: {
+        value: {
+          type: String,
+          default: undefined,
+        },
         sitekey: {
             type: String,
             required: true


### PR DESCRIPTION
Now it is possible to get the token using `v-model` and with that it can be used together with the vee-validate with the `required` rule.