### PR TITLE
feat(actions): Add publish release workflow with NPM OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - master
+
 permissions:
   contents: read
 
@@ -39,10 +40,3 @@ jobs:
         env:
           NODE_OPTIONS: --openssl-legacy-provider
       - run: yarn test --stream
-      - run: cp README.md packages/vue2 && cp README.md packages/vue3
-      - run: cp -r packages/vue2/types packages/vue3
-      - name: "Publish"
-        if: contains('refs/heads/master', github.ref)
-        run: lerna publish -y from-package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build & Test & Publish
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish NPM
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ created ]
+
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC
+
+jobs:
+  build:
+    name: Build & Test & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+          cache: "yarn"
+
+      - name: Install Lerna
+        run: yarn global add lerna@6
+
+      - name: Setup
+        run: yarn setup
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: Build
+        run: yarn build --stream
+      
+      - name: Test
+        run: yarn test --stream
+
+      - name: Copy Version README
+        run: cp README.md packages/vue2 && cp README.md packages/vue3
+
+      - name: Copy Version Directories
+        run: cp -r packages/vue2/types packages/vue3
+
+      - name: "Publish"
+        run: lerna publish -y from-package

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ To publish a new version, follow the next steps:
 1. Bump the versions for both: `vue2/package.json` and `vue3/package.json` (keep them in sync)
 2. Fill [`CHANGES.md`](./CHANGES.md) with change details
 3. Push changes to master.
-   * CI/CD pipeline will publish the new version(s) to: [@hcaptcha/vue-hcaptcha](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha) or [@hcaptcha/vue3-hcaptcha](https://www.npmjs.com/package/@hcaptcha/vue3-hcaptcha).
+4. Create a [Github Release](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/managing-releases-in-a-repository#creating-a-release) with version from step 1 **without** a prefix such as `v` (e.g. `1.0.3`)
+   * `publish` workflow will be triggered which will: bubuild, test and deploy the package to the [@hcaptcha/vue-hcaptcha](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha) or [@hcaptcha/vue3-hcaptcha](https://www.npmjs.com/package/@hcaptcha/vue3-hcaptcha).
 
 ## Contributing + Notable Contributors
 


### PR DESCRIPTION
Switches package publishing from using NPM Auth Token to using NPM OIDC setup. Also adds `publish.yml` to align with other hCaptcha package deployments processes along with isolating the publish flow for better security.